### PR TITLE
Bugfix eventdates fix2

### DIFF
--- a/src/styles/layouts/newsAndEvents/_eventsArticle.scss
+++ b/src/styles/layouts/newsAndEvents/_eventsArticle.scss
@@ -72,7 +72,7 @@
 
           &.eventDate,
           &.eventTime {
-            font-size: clamp(1.2rem, 1.8vw, 1.8rem);
+            font-size: clamp(1.2rem, 1.4vw, 1.8rem);
 
             .separatorUpTo {
               line-height: 0;

--- a/wp-templates/single-event.js
+++ b/wp-templates/single-event.js
@@ -16,6 +16,31 @@ import Preloader from '@/components/atoms/Preloader'
 import { MdForward } from 'react-icons/md'
 import blockEntries from '../wp-blocks'
 
+/**
+ * Format date string to display only month/day/year without time
+ * @param {string} dateString - The date string to format
+ * @returns {string} Formatted date string
+ */
+const formatDateWithoutTime = (dateString) => {
+  if (!dateString) return ''
+  
+  // Check if the date string includes a time component (contains 'T' or ':')
+  const hasTimeComponent = dateString.includes('T') || dateString.includes(':')
+  
+  if (hasTimeComponent) {
+    // Create a Date object and format it to display only month/day/year
+    const date = new Date(dateString)
+    return date.toLocaleDateString('en-US', {
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric'
+    })
+  }
+  
+  // If it's already just a date without time, return as is
+  return dateString
+}
+
 export default function SingleEvent(props) {
   if (props.loading) {
     return <Preloader />
@@ -87,13 +112,13 @@ export default function SingleEvent(props) {
                 <div className="eventDateTime">
                   <div className="eventDate">
                     <EventIcon icon="calendar" />
-                    {event.startDate}{' '}
+                    {formatDateWithoutTime(event.startDate)}{' '}
                     {event.endDate && (
                       <>
                         <span className="separatorUpTo">
                           <MdForward />
                         </span>{' '}
-                        {event.endDate}
+                        {formatDateWithoutTime(event.endDate)}
                       </>
                     )}
                   </div>

--- a/wp-templates/single-event.js
+++ b/wp-templates/single-event.js
@@ -23,10 +23,10 @@ import blockEntries from '../wp-blocks'
  */
 const formatDateWithoutTime = (dateString) => {
   if (!dateString) return ''
-  
+
   // Check if the date string includes a time component (contains 'T' or ':')
   const hasTimeComponent = dateString.includes('T') || dateString.includes(':')
-  
+
   if (hasTimeComponent) {
     // Create a Date object and format it to display only month/day/year
     const date = new Date(dateString)
@@ -36,7 +36,7 @@ const formatDateWithoutTime = (dateString) => {
       year: 'numeric'
     })
   }
-  
+
   // If it's already just a date without time, return as is
   return dateString
 }


### PR DESCRIPTION
### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add date formatting function to display dates without time

- Fix date display in single event template

- Adjust font size for event date and time elements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Event Date Input"] --> B["formatDateWithoutTime()"] --> C["Clean Date Display"]
  D["Font Size Adjustment"] --> E["Better Visual Hierarchy"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>single-event.js</strong><dd><code>Add date formatter for clean display</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

wp-templates/single-event.js

<ul><li>Add <code>formatDateWithoutTime</code> function to strip time components from dates<br> <li> Apply formatter to <code>event.startDate</code> and <code>event.endDate</code> display<br> <li> Handle undefined date inputs with empty string return</ul>


</details>


  </td>
  <td><a href="https://github.com/eab-agency/wilmington-nextjs/pull/434/files#diff-a3b3f9f6251cddc8fefd24d6ac5e44abbc718fbe50d0065b85e17d2fac973ae9">+27/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_eventsArticle.scss</strong><dd><code>Adjust event date/time font sizing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/styles/layouts/newsAndEvents/_eventsArticle.scss

<ul><li>Reduce maximum font size from 1.8vw to 1.4vw for event date and time</ul>


</details>


  </td>
  <td><a href="https://github.com/eab-agency/wilmington-nextjs/pull/434/files#diff-77855457b29ad5bccc45e47521f48502e67d03f9419d2088d6c27163b9b37951">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

